### PR TITLE
load pipelineXML for unicode encoding of file name

### DIFF
--- a/nornir_buildmanager/pipelinemanager.py
+++ b/nornir_buildmanager/pipelinemanager.py
@@ -508,6 +508,8 @@ class PipelineManager(object):
 
     @classmethod
     def LoadPipelineXML(cls, PipelineXML):
+        if isinstance(PipelineXML, unicode):
+            PipelineXML = PipelineXML.encode(sys.getdefaultencoding())
         if isinstance(PipelineXML, str):
             if cls._CheckPipelineXMLExists(PipelineXML):
                 return ElementTree.parse(PipelineXML)


### PR DESCRIPTION
Solve the exception when the directory name of pipelineXML contains non-ASCII characters.