### PR TITLE
Volume metadata migration: XML to SQLite backend

### DIFF
--- a/nornir_buildmanager/metadata/__init__.py
+++ b/nornir_buildmanager/metadata/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['tilesetinfo']
+__all__ = ['tilesetinfo', 'volume_metadata', 'xml_backend', 'sqlite_backend', 'migrate']
 
 from nornir_buildmanager.metadata import tilesetinfo

--- a/nornir_buildmanager/metadata/migrate.py
+++ b/nornir_buildmanager/metadata/migrate.py
@@ -1,0 +1,273 @@
+"""
+Migration tool for converting volume metadata from XML to SQLite.
+
+Usage as a module:
+    from nornir_buildmanager.metadata.migrate import migrate_volume
+    migrate_volume('/path/to/volume')
+
+Usage from command line:
+    python -m nornir_buildmanager.metadata.migrate /path/to/volume [--merge-first] [--db-name VolumeData.db]
+"""
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+from .volume_metadata import MetadataNode
+from .xml_backend import XMLMetadataBackend, save_single_xml
+from .sqlite_backend import SQLiteMetadataBackend, DEFAULT_DB_FILENAME
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationError(Exception):
+    """Raised when migration encounters an unrecoverable error."""
+
+
+class MigrationResult:
+    """Result of a migration operation."""
+    __slots__ = ('success', 'volume_path', 'db_path', 'merged_xml_path',
+                 'node_count', 'attrib_count', 'message')
+
+    def __init__(self):
+        self.success = False
+        self.volume_path = ''
+        self.db_path = ''
+        self.merged_xml_path = None
+        self.node_count = 0
+        self.attrib_count = 0
+        self.message = ''
+
+    def __repr__(self):
+        status = 'OK' if self.success else 'FAILED'
+        return (f"MigrationResult({status}, nodes={self.node_count}, "
+                f"attribs={self.attrib_count}, msg='{self.message}')")
+
+
+def count_tree(node: MetadataNode) -> tuple:
+    """Count nodes and attributes in the metadata tree.
+    Returns (node_count, attrib_count)."""
+    nodes = 0
+    attribs = 0
+    for _, n in node.walk():
+        nodes += 1
+        attribs += len(n.attribs)
+    return nodes, attribs
+
+
+def merge_xml_to_single_file(volume_path: str,
+                              output_filename: str = 'VolumeData_merged.xml') -> Optional[str]:
+    """Load sharded XML (with _Link nodes) and save as a single merged file.
+    Returns the path to the merged file, or None on failure."""
+    xml_backend = XMLMetadataBackend(volume_path, single_file=False)
+    if not xml_backend.exists():
+        logger.error("No XML metadata found at %s", volume_path)
+        return None
+
+    root = xml_backend.load()
+    if root is None:
+        logger.error("Failed to load XML metadata from %s", volume_path)
+        return None
+
+    merged_path = save_single_xml(root, volume_path, output_filename)
+    logger.info("Merged XML saved to %s", merged_path)
+    return merged_path
+
+
+def migrate_volume(volume_path: str,
+                   merge_first: bool = True,
+                   db_filename: str = DEFAULT_DB_FILENAME,
+                   merged_xml_filename: str = 'VolumeData_merged.xml',
+                   force: bool = False) -> MigrationResult:
+    """
+    Migrate volume metadata from XML to SQLite.
+
+    :param volume_path: Path to the volume root directory.
+    :param merge_first: If True, merge sharded XML into a single file before migrating.
+    :param db_filename: Name of the SQLite database file to create.
+    :param merged_xml_filename: Name for the merged XML file (if merge_first=True).
+    :param force: If True, overwrite existing SQLite database.
+    :returns: MigrationResult with details of the operation.
+    """
+    result = MigrationResult()
+    result.volume_path = volume_path
+
+    sqlite_backend = SQLiteMetadataBackend(volume_path, db_filename)
+    result.db_path = sqlite_backend.db_path
+
+    if sqlite_backend.exists() and not force:
+        result.message = (f"SQLite database already exists at {sqlite_backend.db_path}. "
+                          "Use force=True to overwrite.")
+        logger.warning(result.message)
+        return result
+
+    xml_backend = XMLMetadataBackend(volume_path, single_file=False)
+    if not xml_backend.exists():
+        result.message = f"No XML metadata found at {volume_path}"
+        logger.error(result.message)
+        return result
+
+    if merge_first:
+        merged_path = merge_xml_to_single_file(volume_path, merged_xml_filename)
+        result.merged_xml_path = merged_path
+
+    logger.info("Loading XML metadata from %s...", volume_path)
+    root = xml_backend.load()
+    if root is None:
+        result.message = "Failed to load XML metadata"
+        logger.error(result.message)
+        return result
+
+    node_count, attrib_count = count_tree(root)
+    result.node_count = node_count
+    result.attrib_count = attrib_count
+    logger.info("Loaded %d nodes with %d attributes", node_count, attrib_count)
+
+    if sqlite_backend.exists() and force:
+        logger.info("Removing existing database at %s", sqlite_backend.db_path)
+        os.remove(sqlite_backend.db_path)
+
+    logger.info("Writing SQLite database to %s...", sqlite_backend.db_path)
+    sqlite_backend.save(root)
+
+    # Verify round-trip integrity
+    logger.info("Verifying round-trip integrity...")
+    reloaded = sqlite_backend.load()
+    if reloaded is None:
+        result.message = "Failed to reload from SQLite after writing"
+        logger.error(result.message)
+        return result
+
+    rt_nodes, rt_attribs = count_tree(reloaded)
+    if rt_nodes != node_count:
+        result.message = (f"Round-trip node count mismatch: "
+                          f"XML={node_count}, SQLite={rt_nodes}")
+        logger.error(result.message)
+        return result
+
+    if rt_attribs != attrib_count:
+        result.message = (f"Round-trip attribute count mismatch: "
+                          f"XML={attrib_count}, SQLite={rt_attribs}")
+        logger.error(result.message)
+        return result
+
+    result.success = True
+    result.message = (f"Successfully migrated {node_count} nodes and "
+                      f"{attrib_count} attributes to {sqlite_backend.db_path}")
+    logger.info(result.message)
+    return result
+
+
+def verify_migration(volume_path: str,
+                     db_filename: str = DEFAULT_DB_FILENAME) -> bool:
+    """Verify that the SQLite database matches the XML source.
+    Returns True if they match."""
+    xml_backend = XMLMetadataBackend(volume_path, single_file=False)
+    sqlite_backend = SQLiteMetadataBackend(volume_path, db_filename)
+
+    if not xml_backend.exists():
+        logger.error("No XML found for verification")
+        return False
+
+    if not sqlite_backend.exists():
+        logger.error("No SQLite database found for verification")
+        return False
+
+    xml_root = xml_backend.load()
+    sql_root = sqlite_backend.load()
+
+    if xml_root is None or sql_root is None:
+        return False
+
+    return _compare_trees(xml_root, sql_root)
+
+
+def _compare_trees(a: MetadataNode, b: MetadataNode, path: str = '') -> bool:
+    """Recursively compare two metadata trees for structural equality."""
+    current_path = f"{path}/{a.tag}"
+
+    if a.tag != b.tag:
+        logger.error("Tag mismatch at %s: %s vs %s", current_path, a.tag, b.tag)
+        return False
+
+    if a.attribs != b.attribs:
+        diff_keys = set(a.attribs.keys()) ^ set(b.attribs.keys())
+        val_diffs = {k for k in set(a.attribs.keys()) & set(b.attribs.keys())
+                     if a.attribs[k] != b.attribs[k]}
+        logger.error("Attribute mismatch at %s: missing/extra keys=%s, value diffs=%s",
+                      current_path, diff_keys, val_diffs)
+        return False
+
+    # Normalize text comparison (both None and empty/whitespace-only are equivalent)
+    a_text = a.text.strip() if a.text else None
+    b_text = b.text.strip() if b.text else None
+    a_text = a_text if a_text else None
+    b_text = b_text if b_text else None
+    if a_text != b_text:
+        logger.error("Text mismatch at %s: %r vs %r", current_path, a_text, b_text)
+        return False
+
+    if len(a.children) != len(b.children):
+        a_tags = [c.tag for c in a.children]
+        b_tags = [c.tag for c in b.children]
+        logger.error("Child count mismatch at %s: %d vs %d (%s vs %s)",
+                      current_path, len(a.children), len(b.children), a_tags, b_tags)
+        return False
+
+    for ca, cb in zip(a.children, b.children):
+        if not _compare_trees(ca, cb, current_path):
+            return False
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Migrate nornir volume metadata from XML to SQLite'
+    )
+    parser.add_argument('volume_path', help='Path to the volume root directory')
+    parser.add_argument('--merge-first', action='store_true', default=True,
+                        help='Merge sharded XML into a single file before migration (default: True)')
+    parser.add_argument('--no-merge', action='store_true', default=False,
+                        help='Skip the XML merge step')
+    parser.add_argument('--db-name', default=DEFAULT_DB_FILENAME,
+                        help=f'Name of the SQLite database file (default: {DEFAULT_DB_FILENAME})')
+    parser.add_argument('--force', action='store_true', default=False,
+                        help='Overwrite existing SQLite database')
+    parser.add_argument('--verify', action='store_true', default=False,
+                        help='Verify existing migration instead of performing one')
+    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+                        help='Enable verbose logging')
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=log_level, format='%(levelname)s: %(message)s')
+
+    if not os.path.isdir(args.volume_path):
+        logger.error("Volume path does not exist: %s", args.volume_path)
+        sys.exit(1)
+
+    if args.verify:
+        ok = verify_migration(args.volume_path, args.db_name)
+        sys.exit(0 if ok else 1)
+
+    merge_first = args.merge_first and not args.no_merge
+    result = migrate_volume(
+        args.volume_path,
+        merge_first=merge_first,
+        db_filename=args.db_name,
+        force=args.force
+    )
+
+    if result.success:
+        print(f"Migration complete: {result.message}")
+    else:
+        print(f"Migration failed: {result.message}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/nornir_buildmanager/metadata/sqlite_backend.py
+++ b/nornir_buildmanager/metadata/sqlite_backend.py
@@ -1,0 +1,195 @@
+"""
+SQLite backend for volume metadata storage.
+
+Stores the metadata tree in a single SQLite file at the volume root.
+The schema uses a recursive nodes table with a parent_id foreign key,
+plus a separate table for node attributes. This flexibly handles
+arbitrary XML-like trees without requiring a fixed schema per node type.
+
+Schema versioning is built in so older volumes can be migrated forward.
+"""
+
+import logging
+import os
+import sqlite3
+from typing import Optional, Dict, List
+
+from .volume_metadata import MetadataNode, VolumeMetadataBackend
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+DEFAULT_DB_FILENAME = 'VolumeData.db'
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_info (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nodes (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_id INTEGER REFERENCES nodes(id) ON DELETE CASCADE,
+    tag       TEXT NOT NULL,
+    text      TEXT,
+    sort_order INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS node_attribs (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    key     TEXT NOT NULL,
+    value   TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_parent ON nodes(parent_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_tag ON nodes(tag);
+CREATE INDEX IF NOT EXISTS idx_attribs_node ON node_attribs(node_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attribs_node_key ON node_attribs(node_id, key);
+"""
+
+
+class SQLiteMetadataBackend(VolumeMetadataBackend):
+    """Read/write volume metadata from/to a SQLite database file."""
+
+    def __init__(self, volume_path: str, db_filename: str = DEFAULT_DB_FILENAME):
+        self._volume_path = volume_path
+        self._db_filename = db_filename
+        self._db_path = os.path.join(volume_path, db_filename)
+
+    @property
+    def db_path(self) -> str:
+        return self._db_path
+
+    def exists(self) -> bool:
+        return os.path.isfile(self._db_path)
+
+    def get_backend_type(self) -> str:
+        return 'sqlite'
+
+    def get_schema_version(self) -> int:
+        if not self.exists():
+            return 0
+        try:
+            conn = sqlite3.connect(self._db_path)
+            cur = conn.execute("SELECT value FROM schema_info WHERE key='schema_version'")
+            row = cur.fetchone()
+            conn.close()
+            if row:
+                return int(row[0])
+        except Exception:
+            pass
+        return 0
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        conn.executescript(_SCHEMA_SQL)
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_info (key, value) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),)
+        )
+        conn.commit()
+
+    def load(self) -> Optional[MetadataNode]:
+        if not self.exists():
+            return None
+
+        conn = self._get_connection()
+        try:
+            self._maybe_migrate_schema(conn)
+
+            cur = conn.execute(
+                "SELECT id, parent_id, tag, text, sort_order FROM nodes ORDER BY sort_order"
+            )
+            rows = cur.fetchall()
+            if not rows:
+                return None
+
+            cur_attribs = conn.execute(
+                "SELECT node_id, key, value FROM node_attribs"
+            )
+            attrib_map: Dict[int, Dict[str, str]] = {}
+            for node_id, key, value in cur_attribs.fetchall():
+                attrib_map.setdefault(node_id, {})[key] = value
+
+            node_map: Dict[int, MetadataNode] = {}
+            children_map: Dict[int, List[MetadataNode]] = {}
+            root_node = None
+
+            for row_id, parent_id, tag, text, sort_order in rows:
+                node = MetadataNode(
+                    tag=tag,
+                    attribs=attrib_map.get(row_id, {}),
+                    text=text,
+                    db_id=row_id
+                )
+                node_map[row_id] = node
+
+                if parent_id is None:
+                    root_node = node
+                else:
+                    children_map.setdefault(parent_id, []).append(node)
+
+            for nid, node in node_map.items():
+                node.children = children_map.get(nid, [])
+
+            return root_node
+        finally:
+            conn.close()
+
+    def save(self, root: MetadataNode) -> None:
+        os.makedirs(self._volume_path, exist_ok=True)
+
+        conn = self._get_connection()
+        try:
+            self._ensure_schema(conn)
+
+            conn.execute("DELETE FROM node_attribs")
+            conn.execute("DELETE FROM nodes")
+            conn.commit()
+
+            self._insert_node(conn, root, parent_id=None, sort_order=0)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _insert_node(self, conn: sqlite3.Connection, node: MetadataNode,
+                     parent_id: Optional[int], sort_order: int) -> int:
+        cur = conn.execute(
+            "INSERT INTO nodes (parent_id, tag, text, sort_order) VALUES (?, ?, ?, ?)",
+            (parent_id, node.tag, node.text, sort_order)
+        )
+        node_id = cur.lastrowid
+
+        if node.attribs:
+            conn.executemany(
+                "INSERT INTO node_attribs (node_id, key, value) VALUES (?, ?, ?)",
+                [(node_id, k, v) for k, v in node.attribs.items()]
+            )
+
+        for i, child in enumerate(node.children):
+            self._insert_node(conn, child, parent_id=node_id, sort_order=i)
+
+        return node_id
+
+    def _maybe_migrate_schema(self, conn: sqlite3.Connection) -> None:
+        """Migrate the database schema if it is older than the current version.
+        Designed to be extended as new schema versions are added."""
+        try:
+            cur = conn.execute("SELECT value FROM schema_info WHERE key='schema_version'")
+            row = cur.fetchone()
+            current_version = int(row[0]) if row else 0
+        except sqlite3.OperationalError:
+            self._ensure_schema(conn)
+            return
+
+        if current_version < SCHEMA_VERSION:
+            logger.info("Migrating SQLite schema from version %d to %d",
+                        current_version, SCHEMA_VERSION)
+            self._ensure_schema(conn)

--- a/nornir_buildmanager/metadata/volume_metadata.py
+++ b/nornir_buildmanager/metadata/volume_metadata.py
@@ -1,0 +1,88 @@
+"""
+Abstract interface for volume metadata storage backends.
+
+Volume metadata follows the hierarchy:
+  Volume -> Block -> Section -> Channel -> Filter -> {TilePyramid, ImageSet, Tileset, Histogram}
+  Block also contains StosGroup and StosMap entries for slice-to-slice registration.
+
+Each node has arbitrary string attributes stored as key-value pairs. The tree structure
+supports both XML (legacy, sharded or single-file) and SQLite backends.
+"""
+
+import abc
+from typing import Optional, List, Dict, Any, Tuple
+
+
+class MetadataNode:
+    """Represents a single node in the metadata tree, independent of backend."""
+
+    __slots__ = ('tag', 'attribs', 'text', 'children', '_db_id')
+
+    def __init__(self, tag: str, attribs: Optional[Dict[str, str]] = None,
+                 text: Optional[str] = None, children: Optional[List['MetadataNode']] = None,
+                 db_id: Optional[int] = None):
+        self.tag = tag
+        self.attribs = dict(attribs) if attribs else {}
+        self.text = text
+        self.children = list(children) if children else []
+        self._db_id = db_id
+
+    def get(self, attrib_name: str, default: Optional[str] = None) -> Optional[str]:
+        return self.attribs.get(attrib_name, default)
+
+    def find_children(self, tag: str) -> List['MetadataNode']:
+        return [c for c in self.children if c.tag == tag]
+
+    def find_child(self, tag: str, attrib_name: Optional[str] = None,
+                   attrib_value: Optional[str] = None) -> Optional['MetadataNode']:
+        for c in self.children:
+            if c.tag != tag:
+                continue
+            if attrib_name is not None:
+                if c.attribs.get(attrib_name) != attrib_value:
+                    continue
+            return c
+        return None
+
+    def walk(self):
+        """Depth-first iterator yielding (parent, node) tuples. Root yields (None, self)."""
+        yield (None, self)
+        for child in self.children:
+            yield (self, child)
+            for pair in child._walk_children():
+                yield pair
+
+    def _walk_children(self):
+        for child in self.children:
+            yield (self, child)
+            for pair in child._walk_children():
+                yield pair
+
+    def __repr__(self):
+        attrib_str = ' '.join(f'{k}="{v}"' for k, v in sorted(self.attribs.items())[:4])
+        return f"<MetadataNode {self.tag} {attrib_str}>"
+
+
+class VolumeMetadataBackend(abc.ABC):
+    """Abstract backend for reading and writing volume metadata."""
+
+    @abc.abstractmethod
+    def load(self) -> Optional[MetadataNode]:
+        """Load the complete metadata tree and return the root MetadataNode (Volume).
+        Returns None if no metadata exists."""
+
+    @abc.abstractmethod
+    def save(self, root: MetadataNode) -> None:
+        """Persist the complete metadata tree rooted at the given node."""
+
+    @abc.abstractmethod
+    def exists(self) -> bool:
+        """Return True if metadata storage already exists at the configured location."""
+
+    @abc.abstractmethod
+    def get_backend_type(self) -> str:
+        """Return a string identifying the backend type, e.g. 'xml' or 'sqlite'."""
+
+    def get_schema_version(self) -> int:
+        """Return the schema version of the backend storage. Override in subclasses."""
+        return 1

--- a/nornir_buildmanager/metadata/xml_backend.py
+++ b/nornir_buildmanager/metadata/xml_backend.py
@@ -1,0 +1,182 @@
+"""
+XML backend for volume metadata storage.
+
+Wraps the existing VolumeManagerETree XML handling to present it through
+the VolumeMetadataBackend interface. Supports both sharded (per-directory
+VolumeData.xml with _Link nodes) and single-file formats.
+
+This backend handles older XML format variations by being lenient during
+parsing; unknown tags are preserved as-is so that round-tripping does
+not lose data. New format quirks can be added by extending _normalize_element.
+"""
+
+import logging
+import os
+import xml.etree.ElementTree as ElementTree
+from typing import Optional
+
+from .volume_metadata import MetadataNode, VolumeMetadataBackend
+
+logger = logging.getLogger(__name__)
+
+
+class XMLMetadataBackend(VolumeMetadataBackend):
+    """Read/write volume metadata from XML files (VolumeData.xml or Volume.xml)."""
+
+    # Known older file names in order of preference
+    _XML_FILENAMES = ['VolumeData.xml', 'Volume.xml']
+
+    def __init__(self, volume_path: str, single_file: bool = False,
+                 xml_filename: Optional[str] = None):
+        """
+        :param volume_path: Path to the volume root directory.
+        :param single_file: If True, load/save as a monolithic XML file instead of sharded.
+        :param xml_filename: Override the XML filename (default: auto-detect).
+        """
+        self._volume_path = volume_path
+        self._single_file = single_file
+        self._xml_filename = xml_filename
+
+    def _find_xml_path(self) -> Optional[str]:
+        if self._xml_filename:
+            fp = os.path.join(self._volume_path, self._xml_filename)
+            if os.path.isfile(fp):
+                return fp
+            return None
+
+        for name in self._XML_FILENAMES:
+            fp = os.path.join(self._volume_path, name)
+            if os.path.isfile(fp):
+                return fp
+        return None
+
+    def exists(self) -> bool:
+        return self._find_xml_path() is not None
+
+    def get_backend_type(self) -> str:
+        return 'xml'
+
+    def load(self) -> Optional[MetadataNode]:
+        xml_path = self._find_xml_path()
+        if xml_path is None:
+            return None
+
+        try:
+            tree = ElementTree.parse(xml_path)
+        except ElementTree.ParseError as e:
+            logger.error("Failed to parse XML at %s: %s", xml_path, e)
+            return None
+
+        root_elem = tree.getroot()
+
+        if self._single_file:
+            return self._element_to_node(root_elem)
+        else:
+            return self._element_to_node_with_links(root_elem, self._volume_path)
+
+    def save(self, root: MetadataNode) -> None:
+        os.makedirs(self._volume_path, exist_ok=True)
+        filename = self._xml_filename or 'VolumeData.xml'
+        xml_path = os.path.join(self._volume_path, filename)
+
+        root_elem = self._node_to_element(root)
+        tree = ElementTree.ElementTree(root_elem)
+        ElementTree.indent(tree, space='  ')
+        tree.write(xml_path, encoding='utf-8', xml_declaration=True)
+
+    def _element_to_node(self, elem: ElementTree.Element) -> MetadataNode:
+        """Convert an ElementTree element to a MetadataNode, recursively."""
+        children = []
+        for child_elem in elem:
+            children.append(self._element_to_node(child_elem))
+
+        node = MetadataNode(
+            tag=elem.tag,
+            attribs=dict(elem.attrib),
+            text=elem.text.strip() if elem.text and elem.text.strip() else elem.text,
+            children=children
+        )
+        self._normalize_node(node)
+        return node
+
+    def _element_to_node_with_links(self, elem: ElementTree.Element,
+                                     container_path: str) -> MetadataNode:
+        """Convert an ElementTree element to a MetadataNode, resolving _Link nodes
+        by loading their referenced VolumeData.xml from subdirectories."""
+        children = []
+        for child_elem in elem:
+            tag = child_elem.tag
+            if tag.endswith('_Link'):
+                real_tag = tag[:-5]  # Strip '_Link'
+                child_path = child_elem.attrib.get('Path', '')
+                sub_dir = os.path.join(container_path, child_path)
+                sub_xml = os.path.join(sub_dir, 'VolumeData.xml')
+                if os.path.isfile(sub_xml):
+                    try:
+                        sub_tree = ElementTree.parse(sub_xml)
+                        sub_root = sub_tree.getroot()
+                        resolved = self._element_to_node_with_links(sub_root, sub_dir)
+                        children.append(resolved)
+                    except (ElementTree.ParseError, IOError) as e:
+                        logger.warning("Could not load linked XML %s: %s", sub_xml, e)
+                        children.append(MetadataNode(
+                            tag=real_tag,
+                            attribs=dict(child_elem.attrib)
+                        ))
+                else:
+                    children.append(MetadataNode(
+                        tag=real_tag,
+                        attribs=dict(child_elem.attrib)
+                    ))
+            else:
+                children.append(self._element_to_node_with_links(child_elem, container_path))
+
+        node = MetadataNode(
+            tag=elem.tag,
+            attribs=dict(elem.attrib),
+            text=elem.text.strip() if elem.text and elem.text.strip() else elem.text,
+            children=children
+        )
+        self._normalize_node(node)
+        return node
+
+    def _node_to_element(self, node: MetadataNode) -> ElementTree.Element:
+        """Convert a MetadataNode back to an ElementTree element."""
+        elem = ElementTree.Element(node.tag, attrib=node.attribs)
+        if node.text:
+            elem.text = node.text
+        for child in node.children:
+            elem.append(self._node_to_element(child))
+        return elem
+
+    def _normalize_node(self, node: MetadataNode) -> None:
+        """Apply normalization rules for known older XML format variations.
+        Extend this method to handle newly discovered legacy formats."""
+
+        # Older volumes stored section number in 'SectionNumber' instead of 'Number'
+        if node.tag == 'Section':
+            if 'SectionNumber' in node.attribs and 'Number' not in node.attribs:
+                node.attribs['Number'] = node.attribs.pop('SectionNumber')
+
+        # Some old volumes used 'FilterName' instead of 'Name' on Filter elements
+        if node.tag == 'Filter':
+            if 'FilterName' in node.attribs and 'Name' not in node.attribs:
+                node.attribs['Name'] = node.attribs.pop('FilterName')
+
+        # Ensure CreationDate exists (some old formats omit it)
+        # We don't fabricate one; we just note the absence silently
+
+
+def load_xml_as_single_file(volume_path: str, xml_filename: str = 'VolumeData.xml') -> Optional[MetadataNode]:
+    """Convenience function: load XML metadata resolving all links into a single tree."""
+    backend = XMLMetadataBackend(volume_path, single_file=False)
+    return backend.load()
+
+
+def save_single_xml(root: MetadataNode, output_path: str,
+                    filename: str = 'VolumeData_merged.xml') -> str:
+    """Save a MetadataNode tree as a single monolithic XML file.
+    Returns the full path to the written file."""
+    backend = XMLMetadataBackend(output_path, single_file=True, xml_filename=filename)
+    backend.save(root)
+    return os.path.join(output_path, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 
 [project.scripts]
 nornir-build = "nornir_buildmanager.build:Execute"
+nornir-migrate-volume = "nornir_buildmanager.metadata.migrate:main"
 
 [project.optional-dependencies]
 gpu = ["cupy >= 13.0"]

--- a/test/test_metadata_migration.py
+++ b/test/test_metadata_migration.py
@@ -1,0 +1,618 @@
+"""
+Tests for the volume metadata migration system.
+
+Creates synthetic test volumes (XML on disk) and verifies:
+- XML loading via the XMLMetadataBackend
+- SQLite saving/loading via SQLiteMetadataBackend
+- Round-trip fidelity (XML -> MetadataNode -> SQLite -> MetadataNode)
+- Migration tool end-to-end
+- Sharded XML with _Link nodes
+- Older XML format normalization
+- Verification tool
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+# Import the metadata subpackage directly using importlib to avoid triggering
+# the heavy-dependency nornir_buildmanager.__init__ import chain.
+import importlib
+import importlib.util
+
+_workspace = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _import_metadata_module(module_name: str, filename: str):
+    """Import a module from nornir_buildmanager/metadata/ without triggering package __init__."""
+    full_name = f'nornir_buildmanager.metadata.{module_name}'
+    if full_name in sys.modules:
+        return sys.modules[full_name]
+
+    # Ensure parent packages exist as namespace stubs
+    for parent in ['nornir_buildmanager', 'nornir_buildmanager.metadata']:
+        if parent not in sys.modules:
+            parent_mod = importlib.util.module_from_spec(
+                importlib.machinery.ModuleSpec(parent, None, is_package=True)
+            )
+            parent_mod.__path__ = [os.path.join(_workspace, parent.replace('.', '/'))]
+            sys.modules[parent] = parent_mod
+
+    spec = importlib.util.spec_from_file_location(
+        full_name,
+        os.path.join(_workspace, 'nornir_buildmanager', 'metadata', filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_volume_metadata = _import_metadata_module('volume_metadata', 'volume_metadata.py')
+_xml_backend = _import_metadata_module('xml_backend', 'xml_backend.py')
+_sqlite_backend = _import_metadata_module('sqlite_backend', 'sqlite_backend.py')
+_migrate = _import_metadata_module('migrate', 'migrate.py')
+
+MetadataNode = _volume_metadata.MetadataNode
+VolumeMetadataBackend = _volume_metadata.VolumeMetadataBackend
+XMLMetadataBackend = _xml_backend.XMLMetadataBackend
+save_single_xml = _xml_backend.save_single_xml
+SQLiteMetadataBackend = _sqlite_backend.SQLiteMetadataBackend
+migrate_volume = _migrate.migrate_volume
+verify_migration = _migrate.verify_migration
+count_tree = _migrate.count_tree
+merge_xml_to_single_file = _migrate.merge_xml_to_single_file
+MigrationResult = _migrate.MigrationResult
+_compare_trees = _migrate._compare_trees
+
+
+def _build_synthetic_volume_xml() -> str:
+    """Build a realistic VolumeData.xml string matching nornir's schema."""
+    return """<?xml version='1.0' encoding='utf-8'?>
+<Volume Name="TestVolume" Path="." CreationDate="2024-01-15 10:30:00" Version="1.0">
+  <Block Name="TEM" Path="TEM" CreationDate="2024-01-15 10:30:01" Version="1.0">
+    <Section Name="0001" Path="0001" Number="1" CreationDate="2024-01-15 10:30:02" Version="1.0">
+      <Channel Name="TEM" Path="TEM" CreationDate="2024-01-15 10:30:03" Version="1.0">
+        <Scale CreationDate="2024-01-15 10:30:04" Version="1.0">
+          <X UnitsOfMeasure="nm" UnitsPerPixel="2.18"/>
+          <Y UnitsOfMeasure="nm" UnitsPerPixel="2.18"/>
+        </Scale>
+        <Filter Name="Raw" Path="Raw" CreationDate="2024-01-15 10:30:05" Version="1.0" BitsPerPixel="8">
+          <TilePyramid Path="TilePyramid" NumberOfTiles="24" ImageFormatExt=".png" LevelFormat="%03d" CreationDate="2024-01-15 10:30:06" Version="1.0">
+            <Level Path="001" Downsample="1" CreationDate="2024-01-15 10:30:07" Version="1.0"/>
+            <Level Path="002" Downsample="2" CreationDate="2024-01-15 10:30:08" Version="1.0"/>
+            <Level Path="004" Downsample="4" CreationDate="2024-01-15 10:30:09" Version="1.0"/>
+          </TilePyramid>
+          <ImageSet Path="Images" Type="" CreationDate="2024-01-15 10:30:10" Version="1.0">
+            <Level Path="001" Downsample="1" CreationDate="2024-01-15 10:30:11" Version="1.0">
+              <Image Path="image.png" Checksum="abc123" CreationDate="2024-01-15 10:30:12" Version="1.0"/>
+            </Level>
+          </ImageSet>
+          <Histogram Type="Section" CreationDate="2024-01-15 10:30:13" Version="1.0">
+            <Data Path="histogram.xml" Checksum="def456" CreationDate="2024-01-15 10:30:14" Version="1.0"/>
+            <AutoLevelHint UserRequestedMinIntensityCutoff="0.005" UserRequestedMaxIntensityCutoff="0.995" UserRequestedGamma="" CreationDate="2024-01-15 10:30:15" Version="1.0"/>
+          </Histogram>
+        </Filter>
+        <Filter Name="Leveled" Path="Leveled" CreationDate="2024-01-15 10:30:16" Version="1.0" BitsPerPixel="8" MinIntensityCutoff="0.005" MaxIntensityCutoff="0.995" Gamma="1.0" MaskName="Mask">
+          <TilePyramid Path="TilePyramid" NumberOfTiles="24" ImageFormatExt=".png" LevelFormat="%03d" CreationDate="2024-01-15 10:30:17" Version="1.0">
+            <Level Path="001" Downsample="1" CreationDate="2024-01-15 10:30:18" Version="1.0"/>
+          </TilePyramid>
+        </Filter>
+        <Filter Name="Mask" Path="Mask" CreationDate="2024-01-15 10:30:19" Version="1.0" BitsPerPixel="8"/>
+        <Transform Name="Grid" Type="Grid" Path="GridGrid.mosaic" CreationDate="2024-01-15 10:30:20" Version="1.0" InputTransformChecksum="xyz789" Checksum="mosaic_check"/>
+      </Channel>
+    </Section>
+    <Section Name="0002" Path="0002" Number="2" CreationDate="2024-01-15 10:31:00" Version="1.0">
+      <Channel Name="TEM" Path="TEM" CreationDate="2024-01-15 10:31:01" Version="1.0">
+        <Filter Name="Raw" Path="Raw" CreationDate="2024-01-15 10:31:02" Version="1.0" BitsPerPixel="8">
+          <TilePyramid Path="TilePyramid" NumberOfTiles="20" ImageFormatExt=".png" LevelFormat="%03d" CreationDate="2024-01-15 10:31:03" Version="1.0">
+            <Level Path="001" Downsample="1" CreationDate="2024-01-15 10:31:04" Version="1.0"/>
+          </TilePyramid>
+        </Filter>
+      </Channel>
+    </Section>
+    <StosGroup Name="StosBrute" Path="StosBrute" Downsample="8" CreationDate="2024-01-15 10:32:00" Version="1.0">
+      <SectionMappings MappedSectionNumber="2" CreationDate="2024-01-15 10:32:01" Version="1.0">
+        <Transform Name="1" Type="Grid" Path="2-1_ctrl-TEM_Raw_map-TEM_Raw.stos" CreationDate="2024-01-15 10:32:02" Version="1.0"
+                   ControlSectionNumber="1" MappedSectionNumber="2"
+                   ControlChannelName="TEM" ControlFilterName="Raw"
+                   MappedChannelName="TEM" MappedFilterName="Raw"
+                   ControlImageChecksum="aaa" MappedImageChecksum="bbb"
+                   Checksum="stos_check"/>
+      </SectionMappings>
+    </StosGroup>
+    <StosMap Name="FinalStosMap" CreationDate="2024-01-15 10:33:00" Version="1.0" CenterSection="1">
+      <Mapping Control="1" Mapped="2" CreationDate="2024-01-15 10:33:01" Version="1.0"/>
+    </StosMap>
+    <NonStosSectionNumbers CreationDate="2024-01-15 10:34:00" Version="1.0">99,100</NonStosSectionNumbers>
+  </Block>
+  <Notes Path="notes.txt" SourceFilename="notes_orig.txt" CreationDate="2024-01-15 10:35:00" Version="1.0">Some volume notes here</Notes>
+</Volume>"""
+
+
+def _write_synthetic_volume(base_dir: str) -> str:
+    """Create a synthetic volume directory with VolumeData.xml."""
+    vol_path = os.path.join(base_dir, 'TestVolume')
+    os.makedirs(vol_path, exist_ok=True)
+    xml_path = os.path.join(vol_path, 'VolumeData.xml')
+    with open(xml_path, 'w', encoding='utf-8') as f:
+        f.write(_build_synthetic_volume_xml())
+    return vol_path
+
+
+def _write_sharded_volume(base_dir: str) -> str:
+    """Create a sharded volume with _Link nodes pointing to subdirectories."""
+    vol_path = os.path.join(base_dir, 'ShardedVolume')
+    os.makedirs(vol_path, exist_ok=True)
+
+    # Root VolumeData.xml with a Block_Link
+    root_xml = """<?xml version='1.0' encoding='utf-8'?>
+<Volume Name="ShardedVolume" Path="." CreationDate="2024-01-15" Version="1.0">
+  <Block_Link Name="TEM" Path="TEM" CreationDate="2024-01-15" Version="1.0"/>
+</Volume>"""
+    with open(os.path.join(vol_path, 'VolumeData.xml'), 'w') as f:
+        f.write(root_xml)
+
+    # Block subdirectory with Section_Link
+    block_dir = os.path.join(vol_path, 'TEM')
+    os.makedirs(block_dir, exist_ok=True)
+    block_xml = """<?xml version='1.0' encoding='utf-8'?>
+<Block Name="TEM" Path="TEM" CreationDate="2024-01-15" Version="1.0">
+  <Section_Link Name="0001" Path="0001" Number="1" CreationDate="2024-01-15" Version="1.0"/>
+</Block>"""
+    with open(os.path.join(block_dir, 'VolumeData.xml'), 'w') as f:
+        f.write(block_xml)
+
+    # Section subdirectory
+    section_dir = os.path.join(block_dir, '0001')
+    os.makedirs(section_dir, exist_ok=True)
+    section_xml = """<?xml version='1.0' encoding='utf-8'?>
+<Section Name="0001" Path="0001" Number="1" CreationDate="2024-01-15" Version="1.0">
+  <Channel Name="TEM" Path="TEM" CreationDate="2024-01-15" Version="1.0">
+    <Filter Name="Raw" Path="Raw" CreationDate="2024-01-15" Version="1.0" BitsPerPixel="8"/>
+  </Channel>
+</Section>"""
+    with open(os.path.join(section_dir, 'VolumeData.xml'), 'w') as f:
+        f.write(section_xml)
+
+    return vol_path
+
+
+def _write_legacy_volume(base_dir: str) -> str:
+    """Create a volume with legacy XML format (uses 'SectionNumber' instead of 'Number')."""
+    vol_path = os.path.join(base_dir, 'LegacyVolume')
+    os.makedirs(vol_path, exist_ok=True)
+    legacy_xml = """<?xml version='1.0' encoding='utf-8'?>
+<Volume Name="LegacyVolume" Path="." CreationDate="2020-06-01" Version="1.0">
+  <Block Name="TEM" Path="TEM" CreationDate="2020-06-01" Version="1.0">
+    <Section Name="0001" Path="0001" SectionNumber="1" CreationDate="2020-06-01" Version="1.0">
+      <Channel Name="TEM" Path="TEM" CreationDate="2020-06-01" Version="1.0">
+        <Filter FilterName="Raw" Path="Raw" CreationDate="2020-06-01" Version="1.0"/>
+      </Channel>
+    </Section>
+  </Block>
+</Volume>"""
+    with open(os.path.join(vol_path, 'VolumeData.xml'), 'w') as f:
+        f.write(legacy_xml)
+    return vol_path
+
+
+class TestMetadataNode(unittest.TestCase):
+    """Unit tests for the MetadataNode data structure."""
+
+    def test_basic_construction(self):
+        node = MetadataNode('Volume', {'Name': 'Test', 'Path': '.'})
+        self.assertEqual(node.tag, 'Volume')
+        self.assertEqual(node.get('Name'), 'Test')
+        self.assertEqual(node.get('Missing', 'default'), 'default')
+        self.assertEqual(len(node.children), 0)
+
+    def test_find_children(self):
+        child1 = MetadataNode('Section', {'Number': '1'})
+        child2 = MetadataNode('Section', {'Number': '2'})
+        child3 = MetadataNode('Channel', {'Name': 'TEM'})
+        parent = MetadataNode('Block', children=[child1, child2, child3])
+
+        sections = parent.find_children('Section')
+        self.assertEqual(len(sections), 2)
+
+        channels = parent.find_children('Channel')
+        self.assertEqual(len(channels), 1)
+
+    def test_find_child_by_attrib(self):
+        child1 = MetadataNode('Section', {'Number': '1'})
+        child2 = MetadataNode('Section', {'Number': '2'})
+        parent = MetadataNode('Block', children=[child1, child2])
+
+        found = parent.find_child('Section', 'Number', '2')
+        self.assertIsNotNone(found)
+        self.assertEqual(found.get('Number'), '2')
+
+        not_found = parent.find_child('Section', 'Number', '99')
+        self.assertIsNone(not_found)
+
+    def test_walk(self):
+        grandchild = MetadataNode('Filter', {'Name': 'Raw'})
+        child = MetadataNode('Channel', {'Name': 'TEM'}, children=[grandchild])
+        root = MetadataNode('Volume', children=[child])
+
+        walked = list(root.walk())
+        self.assertEqual(len(walked), 3)
+        self.assertIsNone(walked[0][0])  # root has no parent
+        self.assertEqual(walked[0][1].tag, 'Volume')
+        self.assertEqual(walked[1][1].tag, 'Channel')
+        self.assertEqual(walked[2][1].tag, 'Filter')
+
+
+class TestXMLBackend(unittest.TestCase):
+    """Tests for the XML metadata backend."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix='nornir_test_xml_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_load_single_file(self):
+        vol_path = _write_synthetic_volume(self.test_dir)
+        backend = XMLMetadataBackend(vol_path, single_file=True)
+        self.assertTrue(backend.exists())
+
+        root = backend.load()
+        self.assertIsNotNone(root)
+        self.assertEqual(root.tag, 'Volume')
+        self.assertEqual(root.get('Name'), 'TestVolume')
+
+        blocks = root.find_children('Block')
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].get('Name'), 'TEM')
+
+        sections = blocks[0].find_children('Section')
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0].get('Number'), '1')
+        self.assertEqual(sections[1].get('Number'), '2')
+
+    def test_load_sharded_resolves_links(self):
+        vol_path = _write_sharded_volume(self.test_dir)
+        backend = XMLMetadataBackend(vol_path, single_file=False)
+
+        root = backend.load()
+        self.assertIsNotNone(root)
+
+        blocks = root.find_children('Block')
+        self.assertEqual(len(blocks), 1)
+
+        sections = blocks[0].find_children('Section')
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].get('Number'), '1')
+
+        channels = sections[0].find_children('Channel')
+        self.assertEqual(len(channels), 1)
+
+        filters = channels[0].find_children('Filter')
+        self.assertEqual(len(filters), 1)
+        self.assertEqual(filters[0].get('Name'), 'Raw')
+
+    def test_nonexistent_volume(self):
+        backend = XMLMetadataBackend('/nonexistent/path')
+        self.assertFalse(backend.exists())
+        self.assertIsNone(backend.load())
+
+    def test_save_and_reload(self):
+        vol_path = os.path.join(self.test_dir, 'SaveTest')
+        os.makedirs(vol_path)
+
+        root = MetadataNode('Volume', {'Name': 'SavedVol', 'Path': '.'})
+        block = MetadataNode('Block', {'Name': 'TEM', 'Path': 'TEM'})
+        root.children.append(block)
+
+        backend = XMLMetadataBackend(vol_path, single_file=True, xml_filename='VolumeData.xml')
+        backend.save(root)
+
+        self.assertTrue(os.path.isfile(os.path.join(vol_path, 'VolumeData.xml')))
+
+        reloaded = backend.load()
+        self.assertIsNotNone(reloaded)
+        self.assertEqual(reloaded.tag, 'Volume')
+        self.assertEqual(reloaded.get('Name'), 'SavedVol')
+        self.assertEqual(len(reloaded.find_children('Block')), 1)
+
+    def test_legacy_format_normalization(self):
+        vol_path = _write_legacy_volume(self.test_dir)
+        backend = XMLMetadataBackend(vol_path, single_file=True)
+
+        root = backend.load()
+        block = root.find_child('Block')
+        section = block.find_child('Section')
+
+        self.assertEqual(section.get('Number'), '1')
+        self.assertIsNone(section.get('SectionNumber'))
+
+        channel = section.find_child('Channel')
+        filt = channel.find_child('Filter')
+        self.assertEqual(filt.get('Name'), 'Raw')
+        self.assertIsNone(filt.get('FilterName'))
+
+    def test_backend_type(self):
+        backend = XMLMetadataBackend('/tmp')
+        self.assertEqual(backend.get_backend_type(), 'xml')
+
+
+class TestSQLiteBackend(unittest.TestCase):
+    """Tests for the SQLite metadata backend."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix='nornir_test_sqlite_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_save_and_load_simple(self):
+        vol_path = os.path.join(self.test_dir, 'SqliteVol')
+        os.makedirs(vol_path)
+
+        root = MetadataNode('Volume', {'Name': 'TestVol', 'Path': '.'})
+        block = MetadataNode('Block', {'Name': 'TEM', 'Path': 'TEM'})
+        section = MetadataNode('Section', {'Name': '0001', 'Number': '1', 'Path': '0001'})
+        block.children.append(section)
+        root.children.append(block)
+
+        backend = SQLiteMetadataBackend(vol_path)
+        self.assertFalse(backend.exists())
+
+        backend.save(root)
+        self.assertTrue(backend.exists())
+
+        reloaded = backend.load()
+        self.assertIsNotNone(reloaded)
+        self.assertEqual(reloaded.tag, 'Volume')
+        self.assertEqual(reloaded.get('Name'), 'TestVol')
+
+        blocks = reloaded.find_children('Block')
+        self.assertEqual(len(blocks), 1)
+        sections = blocks[0].find_children('Section')
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].get('Number'), '1')
+
+    def test_save_and_load_full_volume(self):
+        """Test with a realistic volume structure."""
+        vol_path = _write_synthetic_volume(self.test_dir)
+
+        xml_backend = XMLMetadataBackend(vol_path, single_file=True)
+        root = xml_backend.load()
+        self.assertIsNotNone(root)
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        sql_backend.save(root)
+
+        reloaded = sql_backend.load()
+        self.assertIsNotNone(reloaded)
+        self.assertTrue(_compare_trees(root, reloaded))
+
+    def test_node_text_preserved(self):
+        vol_path = os.path.join(self.test_dir, 'TextVol')
+        os.makedirs(vol_path)
+
+        root = MetadataNode('Volume', {'Name': 'TextTest'})
+        notes = MetadataNode('NonStosSectionNumbers', text='99,100')
+        root.children.append(notes)
+
+        backend = SQLiteMetadataBackend(vol_path)
+        backend.save(root)
+        reloaded = backend.load()
+
+        nonstos = reloaded.find_child('NonStosSectionNumbers')
+        self.assertIsNotNone(nonstos)
+        self.assertEqual(nonstos.text, '99,100')
+
+    def test_overwrite_existing(self):
+        vol_path = os.path.join(self.test_dir, 'OverwriteVol')
+        os.makedirs(vol_path)
+
+        backend = SQLiteMetadataBackend(vol_path)
+
+        root1 = MetadataNode('Volume', {'Name': 'First'})
+        backend.save(root1)
+
+        root2 = MetadataNode('Volume', {'Name': 'Second'})
+        root2.children.append(MetadataNode('Block', {'Name': 'B1', 'Path': 'B1'}))
+        backend.save(root2)
+
+        reloaded = backend.load()
+        self.assertEqual(reloaded.get('Name'), 'Second')
+        self.assertEqual(len(reloaded.find_children('Block')), 1)
+
+    def test_backend_type(self):
+        backend = SQLiteMetadataBackend('/tmp')
+        self.assertEqual(backend.get_backend_type(), 'sqlite')
+
+    def test_schema_version(self):
+        vol_path = os.path.join(self.test_dir, 'SchemaVol')
+        os.makedirs(vol_path)
+
+        backend = SQLiteMetadataBackend(vol_path)
+        self.assertEqual(backend.get_schema_version(), 0)
+
+        backend.save(MetadataNode('Volume', {'Name': 'Test'}))
+        self.assertEqual(backend.get_schema_version(), 1)
+
+    def test_empty_database(self):
+        vol_path = os.path.join(self.test_dir, 'EmptyVol')
+        os.makedirs(vol_path)
+
+        backend = SQLiteMetadataBackend(vol_path)
+        self.assertIsNone(backend.load())
+
+
+class TestMigration(unittest.TestCase):
+    """End-to-end tests for the migration tool."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix='nornir_test_migrate_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_migrate_synthetic_volume(self):
+        vol_path = _write_synthetic_volume(self.test_dir)
+        result = migrate_volume(vol_path, merge_first=True, force=True)
+
+        self.assertTrue(result.success)
+        self.assertGreater(result.node_count, 0)
+        self.assertGreater(result.attrib_count, 0)
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        self.assertTrue(sql_backend.exists())
+
+        # Verify the database contents match the XML
+        self.assertTrue(verify_migration(vol_path))
+
+    def test_migrate_sharded_volume(self):
+        vol_path = _write_sharded_volume(self.test_dir)
+        result = migrate_volume(vol_path, merge_first=True, force=True)
+
+        self.assertTrue(result.success)
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        root = sql_backend.load()
+        self.assertIsNotNone(root)
+
+        blocks = root.find_children('Block')
+        self.assertEqual(len(blocks), 1)
+
+    def test_migrate_legacy_volume(self):
+        vol_path = _write_legacy_volume(self.test_dir)
+        result = migrate_volume(vol_path, merge_first=False, force=True)
+
+        self.assertTrue(result.success)
+        self.assertTrue(verify_migration(vol_path))
+
+    def test_migrate_refuses_overwrite_without_force(self):
+        vol_path = _write_synthetic_volume(self.test_dir)
+
+        result1 = migrate_volume(vol_path, force=True)
+        self.assertTrue(result1.success)
+
+        result2 = migrate_volume(vol_path, force=False)
+        self.assertFalse(result2.success)
+        self.assertIn('already exists', result2.message)
+
+    def test_migrate_nonexistent_path(self):
+        result = migrate_volume(os.path.join(self.test_dir, 'nonexistent'))
+        self.assertFalse(result.success)
+
+    def test_merge_xml_to_single_file(self):
+        vol_path = _write_sharded_volume(self.test_dir)
+        merged_path = merge_xml_to_single_file(vol_path)
+
+        self.assertIsNotNone(merged_path)
+        self.assertTrue(os.path.isfile(merged_path))
+
+        # Verify the merged file can be loaded
+        backend = XMLMetadataBackend(vol_path, single_file=True,
+                                      xml_filename='VolumeData_merged.xml')
+        root = backend.load()
+        self.assertIsNotNone(root)
+        self.assertEqual(root.tag, 'Volume')
+
+    def test_count_tree(self):
+        root = MetadataNode('Volume', {'Name': 'Test', 'Path': '.'})
+        child = MetadataNode('Block', {'Name': 'B', 'Path': 'B', 'Version': '1'})
+        root.children.append(child)
+
+        nodes, attribs = count_tree(root)
+        self.assertEqual(nodes, 2)
+        self.assertEqual(attribs, 5)  # 2 on Volume + 3 on Block
+
+    def test_round_trip_fidelity(self):
+        """Verify that XML -> SQLite -> MetadataNode matches XML -> MetadataNode."""
+        vol_path = _write_synthetic_volume(self.test_dir)
+
+        xml_backend = XMLMetadataBackend(vol_path, single_file=True)
+        xml_root = xml_backend.load()
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        sql_backend.save(xml_root)
+        sql_root = sql_backend.load()
+
+        self.assertTrue(_compare_trees(xml_root, sql_root))
+
+    def test_deep_hierarchy_roundtrip(self):
+        """Test a deeply nested structure survives the round trip."""
+        vol_path = os.path.join(self.test_dir, 'DeepVol')
+        os.makedirs(vol_path)
+
+        node = MetadataNode('Volume', {'Name': 'Deep', 'Path': '.'})
+        current = node
+        for i in range(10):
+            child = MetadataNode(f'Level{i}', {'Depth': str(i)})
+            current.children.append(child)
+            current = child
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        sql_backend.save(node)
+        reloaded = sql_backend.load()
+
+        self.assertTrue(_compare_trees(node, reloaded))
+
+    def test_many_children_order_preserved(self):
+        """Test that child ordering is preserved through SQLite."""
+        vol_path = os.path.join(self.test_dir, 'OrderVol')
+        os.makedirs(vol_path)
+
+        root = MetadataNode('Volume', {'Name': 'Order'})
+        for i in range(50):
+            root.children.append(MetadataNode('Section', {'Number': str(i)}))
+
+        sql_backend = SQLiteMetadataBackend(vol_path)
+        sql_backend.save(root)
+        reloaded = sql_backend.load()
+
+        for i, child in enumerate(reloaded.children):
+            self.assertEqual(child.get('Number'), str(i),
+                             f"Child order not preserved at index {i}")
+
+
+class TestCompareTreesFunction(unittest.TestCase):
+    """Tests for the tree comparison utility."""
+
+    def test_identical_trees(self):
+        a = MetadataNode('Volume', {'Name': 'Test'}, children=[
+            MetadataNode('Block', {'Name': 'B1'})
+        ])
+        b = MetadataNode('Volume', {'Name': 'Test'}, children=[
+            MetadataNode('Block', {'Name': 'B1'})
+        ])
+        self.assertTrue(_compare_trees(a, b))
+
+    def test_tag_mismatch(self):
+        a = MetadataNode('Volume')
+        b = MetadataNode('NotVolume')
+        self.assertFalse(_compare_trees(a, b))
+
+    def test_attrib_mismatch(self):
+        a = MetadataNode('Volume', {'Name': 'A'})
+        b = MetadataNode('Volume', {'Name': 'B'})
+        self.assertFalse(_compare_trees(a, b))
+
+    def test_child_count_mismatch(self):
+        a = MetadataNode('Volume', children=[MetadataNode('Block')])
+        b = MetadataNode('Volume', children=[MetadataNode('Block'), MetadataNode('Block')])
+        self.assertFalse(_compare_trees(a, b))
+
+    def test_text_mismatch(self):
+        a = MetadataNode('Notes', text='hello')
+        b = MetadataNode('Notes', text='world')
+        self.assertFalse(_compare_trees(a, b))
+
+    def test_whitespace_text_treated_as_none(self):
+        a = MetadataNode('Notes', text=None)
+        b = MetadataNode('Notes', text='  \n  ')
+        self.assertTrue(_compare_trees(a, b))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a metadata migration system that enables converting nornir volume metadata from the existing XML format (sharded `VolumeData.xml` files with `_Link` nodes) to a single SQLite database file per volume.

## Architecture

### Abstract Interface (`volume_metadata.py`)
- **`MetadataNode`** — Backend-agnostic tree node representing a metadata element with tag, attributes, text, and children. Supports querying (find_children, find_child, walk).
- **`VolumeMetadataBackend`** — Abstract base class defining `load()`, `save()`, `exists()`, and `get_backend_type()` for any storage backend.

### XML Backend (`xml_backend.py`)
- Loads both single-file and sharded XML, resolving `_Link` nodes by traversing subdirectories.
- Normalizes legacy XML format variations (e.g., `SectionNumber` → `Number`, `FilterName` → `Name`).
- Extensible `_normalize_node()` method for adding support for older formats as they are discovered.

### SQLite Backend (`sqlite_backend.py`)
- Stores the metadata tree in a single `VolumeData.db` file at the volume root.
- Flexible schema: `nodes` table (recursive parent_id, tag, text, sort_order) + `node_attribs` table (key-value pairs).
- Built-in schema versioning via `schema_info` table for forward migration.
- Uses WAL journal mode and foreign keys for integrity.

### Migration Tool (`migrate.py`)
- `migrate_volume()` — End-to-end migration: loads XML, optionally merges sharded XML into a single file first, writes to SQLite, verifies round-trip integrity.
- `merge_xml_to_single_file()` — Resolves all `_Link` references and saves as a single merged XML.
- `verify_migration()` — Compares XML source against SQLite database for structural equality.
- CLI entry point: `nornir-migrate-volume` (also `python -m nornir_buildmanager.metadata.migrate`).

### Tests (`test/test_metadata_migration.py`)
33 tests covering:
- MetadataNode data structure operations
- XML backend: single-file, sharded link resolution, legacy format normalization
- SQLite backend: save/load, full realistic volumes, text preservation, child ordering, schema versioning
- Migration: end-to-end, sharded volumes, legacy formats, overwrite protection, round-trip fidelity
- Tree comparison utility edge cases

All tests use synthetic test volumes generated in-memory — no external test data required.

## Usage

```bash
# Migrate a volume (merges XML first, then converts to SQLite)
nornir-migrate-volume /path/to/volume --force

# Skip XML merge step
nornir-migrate-volume /path/to/volume --no-merge --force

# Verify an existing migration
nornir-migrate-volume /path/to/volume --verify

# Programmatic usage
from nornir_buildmanager.metadata.migrate import migrate_volume
result = migrate_volume('/path/to/volume', merge_first=True, force=True)
print(result)
```

## Design Decisions

- **Flexible schema** over fixed tables: the XML metadata has many node types with varying attributes. A generic `nodes` + `node_attribs` design handles any tree structure without schema changes when new node types are added.
- **Legacy format support**: normalization hooks in `_normalize_node()` can be extended as older XML variations are encountered, without modifying the core migration logic.
- **Round-trip verification**: every migration automatically verifies the SQLite output matches the XML input.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://marclabconnectomics.slack.com/archives/C01BT1G6PV0/p1775123516168939?thread_ts=1775123516.168939&cid=C01BT1G6PV0)

<div><a href="https://cursor.com/agents/bc-fc50a9dd-92ec-5c25-b972-071798db109d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc50a9dd-92ec-5c25-b972-071798db109d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

